### PR TITLE
Actually make the build work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 LUADIR ?= ../lua
 LUA ?= $(LUADIR)/bin/lua
 LUAINC ?= $(LUADIR)/include
+LUALIBDIR ?= $(LUADIR)/lib
+LUALIB ?= lua
 
 # ----------------------------------------------------------------------
 
@@ -21,7 +23,7 @@ AR ?= ar
 
 INCFLAGS= -I$(LUAINC)
 CFLAGS= -Os -fPIC $(INCFLAGS) 
-LDFLAGS= -fPIC
+LDFLAGS= -fPIC -L$(LUALIBDIR) -l$(LUALIB)
 
 OBJS= luanacha.o monocypher.o randombytes.o
 


### PR DESCRIPTION
With these changes, `make LUA=$(which lua-5.2) LUADIR=/usr/local/opt/lua clean luanacha.so test` works on macOS for me (after `brew install lua` which installs 5.2).

I am unsure how your Makefile can work on any system as it does not link in liblua at all. How did you make `make test` work for you?